### PR TITLE
Changes to support 32-bit on Linux, and do not abort when connections are down

### DIFF
--- a/librpc/rdtsc.h
+++ b/librpc/rdtsc.h
@@ -26,9 +26,22 @@ static __inline__ uint64_t
 rdtsc(void) {
     uint32_t lo, hi;
 
+#ifdef __x86_64__
     __asm__ __volatile__ (      // serialize
     "xorl %%eax,%%eax \n        cpuid"
     ::: "%rax", "%rbx", "%rcx", "%rdx");
+#else
+	/*
+	 * http://newbiz.github.io/cpp/2010/12/20/Playing-with-cpuid.html#heading_toc_j_5
+	 */
+	asm volatile ( "xorl %%eax,%%eax\n"
+		"pushl %%ebx\n"
+		"cpuid\n"
+		"popl %%ebx\n"
+		::: "%eax", "%ecx", "%edx"
+	);
+#endif
+
     /*
      * We cannot use "=A", since this would use %rax on x86_64
      * and return only the lower 32bits of the TSC

--- a/librpc/svc.c
+++ b/librpc/svc.c
@@ -442,7 +442,7 @@ xprt_to_mtxprt(SVCXPRT *xprt)
     if (mtxprt->mtxp_magic != MTXPRT_MAGIC) {
         teprintf("xprt=%s -- Bad magic, %x.\n",
             decode_addr(xprt), mtxprt->mtxp_magic);
-        svc_die();
+		return NULL;
     }
 
     return (mtxprt);
@@ -1974,6 +1974,8 @@ svc_return(SVCXPRT *xprt)
     mtxprt_t *mtxprt;
 
     mtxprt = xprt_to_mtxprt(xprt);
+	if (!mtxprt)
+		return;
 
     tprintf(2, "xprt=%s, fd=%d\n", decode_addr(xprt), xprt->xp_sock);
 

--- a/librpc/svc_debug.h
+++ b/librpc/svc_debug.h
@@ -52,6 +52,7 @@ extern pthread_mutex_t trace_lock;
         pthread_mutex_unlock(&trace_lock); \
     })
 
+#ifdef __x86_64__
 #define trace_printf_with_lock(fmt, ...) \
     ({ \
         dbuf_thread_reset(); \
@@ -61,6 +62,17 @@ extern pthread_mutex_t trace_lock;
             ## __VA_ARGS__); \
         fflush(stderr); \
     })
+#else
+#define trace_printf_with_lock(fmt, ...) \
+    ({ \
+        dbuf_thread_reset(); \
+        fflush(stderr); \
+        fprintf(stderr, "\n@%#x:%s:%u:%s: " fmt, \
+            (uintptr_t)pthread_self(), __FILE__, __LINE__, __FUNCTION__, \
+            ## __VA_ARGS__); \
+        fflush(stderr); \
+    })
+#endif
 
 #define trace_printf(fmt, ...) \
     ({ \
@@ -69,6 +81,7 @@ extern pthread_mutex_t trace_lock;
         pthread_mutex_unlock(&trace_lock); \
     })
 
+#ifdef __x86_64__
 #define teprintf_with_lock(fmt, ...) \
     ({ \
         dbuf_thread_reset(); \
@@ -78,6 +91,17 @@ extern pthread_mutex_t trace_lock;
             ## __VA_ARGS__); \
         fflush(stderr); \
     })
+#else
+#define teprintf_with_lock(fmt, ...) \
+    ({ \
+        dbuf_thread_reset(); \
+        fflush(stderr); \
+        fprintf(stderr, "\n@%#x:%s:%u:%s: ***ERROR***\n    " fmt, \
+            (uintptr_t)pthread_self(), __FILE__, __LINE__, __FUNCTION__, \
+            ## __VA_ARGS__); \
+        fflush(stderr); \
+    })
+#endif
 
 #define teprintf(fmt, ...) \
     ({ \


### PR DESCRIPTION
1. minor changes, with #ifdef __x86_64__, to build rpc-mt libraries in 32-bit on Linux;
2. svc_die() is called to abort applications, when RPC clients close connections before receiving responses. To keep the applications running, a NULL is returned by xprt_to_mtxprt() instead of calling svc_die().